### PR TITLE
Add a radar geocoding module + cli

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,16 @@
+## Frequently Asked Questions
+
+### 1. What's the sign convention of the line-of-sight data?
+
+**Summary**:
+
+- In the `timeseries/` folder, positive means motion *toward* the sensor, and negative means motion *away* from the sensor.
+- In the `interferograms/` folder, the sign is flipped and positive phase means motion *away* from the sensor.
+
+`dolphin` follows similar sign conventions to other InSAR software such as isce2 and MintPy.
+Inteferograms in `dolphin` are formed as `reference_slc * conj(secondary_slc)`. The phase of the complex values in the `interferograms/` folder indicates an increase in the line-of-sight (LOS) direction from the sensor, while a negative value indicates a decrease (motion towards the sensor).
+
+After unwrapping, the sign convention is flipped and converted to meters (if the `wavelength` parameter is set) for the outputs in the `timeseries` folder.
+Assuming the `wavelength` parameter is set, the unwrapped phase is multiplied by $-4\pi / \lambda$, so positive values in the timeseries rasters indicate motion *toward* the sensor, and negative values indicate motion *away* from the sensor. Thus, when combining two LOS rasters from ascending and descending geometries, postive values in both indicate that uplift is occurring.
+
+Note that `dolphin` is able to process coregistered SLCs from arbitrary processing software, and does not always attempt to guess what sensor the SLCs are derived from. If the `wavelength` (within the `input_options` group) is not set in during configuration, the outputs in the `timeseries` folder will remain in radians, but keep the same sign convention (positive = motion toward the sensor).

--- a/docs/how-to-geocode-radar-results.md
+++ b/docs/how-to-geocode-radar-results.md
@@ -1,0 +1,120 @@
+# How to geocode dolphin results (ISCE2 / ISCE3)
+
+After running dolphin on radar-geometry data processed with ISCE2 or ISCE3, the
+outputs (interferograms, unwrapped phase, time series, velocity) are still in
+swath/radar coordinates. The `dolphin geocode` command transforms them to
+geographic coordinates using per-pixel latitude/longitude arrays from ISCE's
+geometry products.
+
+It auto-detects the geolocation file naming convention:
+
+| Processor           | Geometry directory       | Lat file  | Lon file  |
+| ------------------- | ------------------------ | --------- | --------- |
+| ISCE3 / dolphin     | `geometry/`              | `y.tif`   | `x.tif`   |
+| ISCE2 topsStack     | `merged/geom_reference/` | `lat.rdr` | `lon.rdr` |
+| ISCE2 stripmapStack | `geom_reference/`        | `lat.rdr` | `lon.rdr` |
+
+## Bulk geocode a dolphin work directory
+
+The simplest way to geocode all outputs at once. This discovers rasters in
+`timeseries/`, `unwrapped/`, etc. and writes geocoded results to
+`<dolphin-dir>/geocoded/`, mirroring the directory structure.
+
+```bash
+dolphin geocode \
+    -d ./dolphin_output \
+    -g ./geometry \
+    -c dolphin_config.yaml
+```
+
+The `-c` flag reads `output_options.strides` from your config so the
+geolocation arrays (which are at full resolution) are properly subsampled to
+match your multilooked outputs.
+
+## ISCE2 topsStack example
+
+```bash
+dolphin geocode \
+    -d ./dolphin_output \
+    -g ./merged/geom_reference \
+    -c dolphin_config.yaml
+```
+
+## ISCE2 stripmapStack example
+
+```bash
+dolphin geocode \
+    -d ./dolphin_output \
+    -g ./geom_reference \
+    -c dolphin_config.yaml
+```
+
+## Geocode specific files
+
+You can also pass individual files instead of a whole directory:
+
+```bash
+# Single file
+dolphin geocode -i velocity.tif -g geometry/
+
+# Multiple files to an output directory
+dolphin geocode \
+    -i timeseries/velocity.tif \
+    -i unwrapped/20220101_20220201.unw.tif \
+    -g geometry/ \
+    -o geocoded/
+```
+
+## Reproject to UTM with a specific pixel spacing
+
+```bash
+dolphin geocode \
+    -d ./dolphin_output \
+    -g ./geometry \
+    -c dolphin_config.yaml \
+    --srs 32610 \
+    -s 30
+```
+
+This reprojects to UTM zone 10N (EPSG:32610) with 30-meter pixel spacing.
+
+## Apply a mask during geocoding
+
+Pass a binary mask (0 = invalid, nonzero = valid) to mark pixels as nodata in
+the geocoded output. The mask can be at the strided resolution or at full
+resolution (it will be subsampled automatically if strides are set).
+
+```bash
+dolphin geocode \
+    -i velocity.tif \
+    -g geometry/ \
+    -c dolphin_config.yaml \
+    --mask water_mask.tif
+```
+
+## Include additional products
+
+By default, bulk mode geocodes time series and unwrapped interferograms. Use
+flags to include more:
+
+```bash
+dolphin geocode \
+    -d ./dolphin_output \
+    -g ./geometry \
+    --include-interferograms \
+    --include-auxiliary
+```
+
+| Flag                       | What it adds                                                       |
+| -------------------------- | ------------------------------------------------------------------ |
+| `--include-unwrapped`      | Unwrapped interferograms (on by default)                           |
+| `--include-interferograms` | Wrapped interferograms, similarity, temporal/multilooked coherence |
+| `--include-auxiliary`      | CRLB, amplitude dispersion                                         |
+
+## Parallel processing
+
+Geocoding is parallelized across files. Control the number of workers with `-j`:
+
+```bash
+dolphin geocode -d ./dolphin_output -g ./geometry -j 4
+```

--- a/docs/how-to-guides.md
+++ b/docs/how-to-guides.md
@@ -1,0 +1,3 @@
+# How-to Guides
+
+- [How to geocode dolphin results (ISCE2 / ISCE3)](./how-to-geocode-radar-results.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@
 1. [Getting started](./getting-started.md)
 1. [Overview of processing modules](./overview.md)
 1. [Tutorials](tutorials.md)
+1. [How-To Guides](how-to-guides.md)
+1. [FAQ](faq.md)
 1. [Code Reference](reference/summary.md)
 1. [Changelog](changelog.md)
-<!-- 1. [How-To Guides](how-to-guides.md) -->
-<!-- 1. [Background theory](background-theory.md) -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,9 +61,9 @@ nav:
 # - Tutorials:
 #   - Notebook page: notebooks/walkthrough-basic.ipynb
 #   # - Notebook page2: notebooks/walkthrough-basic.html
-# - how-to-guides.md
+- how-to-guides.md
+- faq.md
 # https://mkdocstrings.github.io/recipes/#generate-a-literate-navigation-file
 # trailing slash: that mkdocs-literate-nav knows a summary.md file is in that folder.
 - developer-setup.md
 - Code Reference: reference/
-# - background-theory.md

--- a/src/dolphin/cli.py
+++ b/src/dolphin/cli.py
@@ -17,6 +17,7 @@ def main() -> int:
     import tyro
 
     from dolphin.filtering import filter_rasters
+    from dolphin.geocode import run as run_geocode
     from dolphin.timeseries import run as run_timeseries
     from dolphin.unwrap import run as run_unwrap
     from dolphin.workflows._cli_config import ConfigCli
@@ -28,6 +29,7 @@ def main() -> int:
             "unwrap": run_unwrap,
             "timeseries": run_timeseries,
             "filter": filter_rasters,
+            "geocode": run_geocode,
         },
         prog=__package__,
     )

--- a/src/dolphin/geocode.py
+++ b/src/dolphin/geocode.py
@@ -1,0 +1,566 @@
+"""Geocode rasters from radar to geographic coordinates using geolocation arrays."""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from collections.abc import Sequence
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from functools import partial
+from pathlib import Path
+from typing import Annotated
+
+import numpy as np
+import tyro
+from osgeo import gdal, osr
+
+from dolphin import io
+
+gdal.UseExceptions()
+
+logger = logging.getLogger("dolphin")
+
+__all__ = ["geocode_with_geolocation_arrays", "run"]
+
+DEFAULT_TIFF_OPTIONS = (
+    "COMPRESS=lzw",
+    "BIGTIFF=IF_SAFER",
+    "TILED=yes",
+    "INTERLEAVE=band",
+    "BLOCKXSIZE=512",
+    "BLOCKYSIZE=512",
+)
+
+
+def geocode_with_geolocation_arrays(
+    input_file: Path | str,
+    lat_file: Path | str,
+    lon_file: Path | str,
+    output_file: Path | str | None = None,
+    mask_file: Path | str | None = None,
+    output_srs: str | int | None = None,
+    spacing: tuple[float, float] | float | None = None,
+    output_format: str = "GTiff",
+    bounds: tuple[float, float, float, float] | None = None,
+    resampling_method: str = "near",
+    strides: tuple[int, int] | None = None,
+    creation_options: Sequence[str] = DEFAULT_TIFF_OPTIONS,
+) -> Path:
+    """Geocode a swath file using latitude and longitude geolocation arrays.
+
+    Uses GDAL's geolocation array warping to transform radar/swath geometry
+    data to a geographic or projected coordinate system.
+
+    Parameters
+    ----------
+    input_file : Path or str
+        Path to the input swath file to geocode.
+    lat_file : Path or str
+        Path to file containing per-pixel latitude values (e.g., from ISCE topo).
+    lon_file : Path or str
+        Path to file containing per-pixel longitude values.
+    output_file : Path or str, optional
+        Path for the output geocoded file. Default is ``<input>.geo.<ext>``.
+    mask_file : Path or str, optional
+        Path to a mask raster in the same geometry as `input_file`.
+        Convention: 0 = invalid, nonzero = valid (SNAPHU/ISCE convention).
+        If the mask is at full resolution and `strides` are given, it will be
+        subsampled to match the input.
+    output_srs : str or int, optional
+        Output spatial reference system as EPSG code (int) or WKT/proj4 string.
+        If None, defaults to EPSG:4326 (WGS84 geographic).
+    spacing : tuple of float or float, optional
+        Output pixel spacing as ``(x_res, y_res)`` or a single value for both.
+        If None, GDAL determines spacing automatically.
+    output_format : str, default="GTiff"
+        GDAL driver name for the output format.
+    bounds : tuple of float, optional
+        Output bounds as ``(xmin, ymin, xmax, ymax)`` in output SRS coordinates.
+    resampling_method : str, default="near"
+        GDAL resampling algorithm (e.g., "near", "bilinear", "cubic").
+    strides : tuple of int, optional
+        Strides as ``(row_stride, col_stride)`` indicating the additional spacing
+        in the `input_file` compared to `lat_file` and `lon_file`.
+        For example, if multilooked interferograms were created with
+        2 range (col) and 3 azimuth (row) strides, set ``strides=(3, 2)``.
+    creation_options : list of str, optional
+        GDAL creation options for the output file.
+
+    Returns
+    -------
+    Path
+        Path to the created geocoded file.
+
+    Notes
+    -----
+    The geolocation arrays (lat/lon files) are assumed to be in WGS84 (EPSG:4326),
+    which is standard for ISCE2/ISCE3 topo outputs.
+
+    When using `strides`, the lat/lon arrays are subsampled via VRT to match
+    the input resolution before warping.
+
+    """
+    input_file = Path(input_file)
+    lat_file = Path(lat_file)
+    lon_file = Path(lon_file)
+    mask_file = Path(mask_file) if mask_file is not None else None
+
+    if output_file is None:
+        output_file = input_file.with_suffix(f".geo{input_file.suffix}")
+    output_file = Path(output_file)
+
+    # Parse spacing input
+    if spacing is None:
+        x_res, y_res = None, None
+    elif isinstance(spacing, int | float):
+        x_res = y_res = float(spacing)
+    else:
+        x_res, y_res = spacing
+
+    # Parse strides
+    if strides is None:
+        row_stride, col_stride = 1, 1
+    else:
+        row_stride, col_stride = strides
+
+    # VRT XML template for source bands
+    source_xml_template = """\
+    <SimpleSource>
+      <SourceFilename>{filename}</SourceFilename>
+      <SourceBand>{band}</SourceBand>
+    </SimpleSource>"""
+
+    input_ds = gdal.Open(str(input_file), gdal.GA_ReadOnly)
+    assert input_ds is not None, f"Could not open {input_file}"
+
+    # Check if mask needs subsampling to match input (when strides are used)
+    mask_needs_subsample = False
+    if mask_file is not None:
+        mask_ds = gdal.Open(str(mask_file), gdal.GA_ReadOnly)
+        assert mask_ds is not None, f"Could not open mask file {mask_file}"
+
+        mask_matches = (
+            mask_ds.RasterXSize == input_ds.RasterXSize
+            and mask_ds.RasterYSize == input_ds.RasterYSize
+        )
+        # Check if mask matches input*strides (full-res mask for multilooked input)
+        mask_matches_with_strides = (
+            mask_ds.RasterXSize == input_ds.RasterXSize * col_stride
+            and mask_ds.RasterYSize == input_ds.RasterYSize * row_stride
+        )
+
+        if not mask_matches and not mask_matches_with_strides:
+            expected_strided = (
+                input_ds.RasterYSize * row_stride,
+                input_ds.RasterXSize * col_stride,
+            )
+            msg = (
+                f"Mask shape {mask_ds.RasterYSize, mask_ds.RasterXSize} must match "
+                f"input {input_ds.RasterYSize, input_ds.RasterXSize} or "
+                f"input*strides {expected_strided}"
+            )
+            raise ValueError(msg)
+
+        mask_needs_subsample = mask_matches_with_strides and not mask_matches
+        mask_ds = None
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        temp_vrt_path = tmp_path / "geocode.vrt"
+        mask_alpha_file = None
+
+        if mask_file is not None:
+            # If mask is at full resolution but input is multilooked, subsample
+            mask_to_use = mask_file
+            if mask_needs_subsample:
+                subsampled_mask = tmp_path / "mask_subsampled.vrt"
+                _create_subsampled_vrt(
+                    mask_file, subsampled_mask, row_stride, col_stride
+                )
+                mask_to_use = subsampled_mask
+
+            # Convert mask to alpha band: 255=valid, 0=invalid
+            # Assumes 0=invalid, nonzero=valid (SNAPHU/ISCE convention)
+            mask_alpha_file = tmp_path / "mask_alpha.tif"
+            _create_alpha_from_mask(mask_to_use, mask_alpha_file)
+
+        # If strides > 1, subsample lat/lon arrays to match input size
+        lat_to_use: Path | str = lat_file
+        lon_to_use: Path | str = lon_file
+        if row_stride > 1 or col_stride > 1:
+            subsampled_lat = tmp_path / "lat_subsampled.vrt"
+            subsampled_lon = tmp_path / "lon_subsampled.vrt"
+            _create_subsampled_vrt(lat_file, subsampled_lat, row_stride, col_stride)
+            _create_subsampled_vrt(lon_file, subsampled_lon, row_stride, col_stride)
+            lat_to_use = subsampled_lat
+            lon_to_use = subsampled_lon
+
+        # Create VRT with geolocation metadata
+        driver = gdal.GetDriverByName("VRT")
+        vrt_ds = driver.Create(
+            str(temp_vrt_path), input_ds.RasterXSize, input_ds.RasterYSize, 0
+        )
+
+        # Copy bands from input to VRT
+        nodata_vals = []
+        for band_idx in range(input_ds.RasterCount):
+            band = input_ds.GetRasterBand(band_idx + 1)
+            vrt_ds.AddBand(band.DataType)
+            nodata_vals.append(band.GetNoDataValue())
+            source_xml = source_xml_template.format(
+                filename=str(input_file), band=band_idx + 1
+            )
+            vrt_ds.GetRasterBand(band_idx + 1).SetMetadata(
+                {"source_0": source_xml}, "vrt_sources"
+            )
+
+        if mask_alpha_file is not None:
+            alpha_band_index = input_ds.RasterCount + 1
+            vrt_ds.AddBand(gdal.GDT_Byte)
+            alpha_band = vrt_ds.GetRasterBand(alpha_band_index)
+            alpha_band.SetColorInterpretation(gdal.GCI_AlphaBand)
+            source_xml = source_xml_template.format(
+                filename=str(mask_alpha_file), band=1
+            )
+            alpha_band.SetMetadata({"source_0": source_xml}, "vrt_sources")
+
+        # Geolocation arrays are in WGS84
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(4326)
+        srs.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
+
+        # Set geolocation metadata. When strides are used, we've already subsampled
+        # the lat/lon arrays to match the input, so PIXEL_STEP=LINE_STEP=1.
+        vrt_ds.SetMetadata(
+            {
+                "SRS": srs.ExportToWkt(),
+                "X_DATASET": str(lon_to_use),
+                "X_BAND": "1",
+                "Y_DATASET": str(lat_to_use),
+                "Y_BAND": "1",
+                "PIXEL_OFFSET": "0",
+                "LINE_OFFSET": "0",
+                "PIXEL_STEP": "1",
+                "LINE_STEP": "1",
+            },
+            "GEOLOCATION",
+        )
+        for i in range(len(nodata_vals)):
+            if nodata_vals[i] is not None:
+                vrt_ds.GetRasterBand(i + 1).SetNoDataValue(nodata_vals[i])
+
+        # Flush before warping
+        vrt_ds = None
+        input_ds = None
+
+        warp_options = gdal.WarpOptions(
+            format=output_format,
+            xRes=x_res,
+            yRes=y_res,
+            dstSRS=output_srs,
+            outputBounds=bounds,
+            resampleAlg=resampling_method,
+            geoloc=True,
+            srcAlpha=mask_alpha_file is not None,
+            dstNodata=np.nan,
+            creationOptions=creation_options,
+        )
+        gdal.Warp(str(output_file), str(temp_vrt_path), options=warp_options)
+
+    return output_file
+
+
+def _create_subsampled_vrt(
+    input_file: Path,
+    output_file: Path,
+    row_stride: int,
+    col_stride: int,
+) -> Path:
+    """Create a VRT that subsamples a raster by the given strides."""
+    input_ds = gdal.Open(str(input_file), gdal.GA_ReadOnly)
+    assert input_ds is not None, f"Could not open {input_file}"
+
+    in_width = input_ds.RasterXSize
+    in_height = input_ds.RasterYSize
+    out_width = in_width // col_stride
+    out_height = in_height // row_stride
+
+    band = input_ds.GetRasterBand(1)
+    dtype_name = gdal.GetDataTypeName(band.DataType)
+    nodata = band.GetNoDataValue()
+    nodata_xml = f"<NoDataValue>{nodata}</NoDataValue>" if nodata is not None else ""
+    input_ds = None
+
+    # VRT with SrcRect covering full input, DstRect smaller -> GDAL subsamples
+    vrt_xml = f"""\
+<VRTDataset rasterXSize="{out_width}" rasterYSize="{out_height}">
+  <VRTRasterBand dataType="{dtype_name}" band="1">
+    {nodata_xml}
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">{input_file}</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="{in_width}" ySize="{in_height}"/>
+      <DstRect xOff="0" yOff="0" xSize="{out_width}" ySize="{out_height}"/>
+    </SimpleSource>
+  </VRTRasterBand>
+</VRTDataset>"""
+
+    output_file.write_text(vrt_xml)
+    return output_file
+
+
+def _create_alpha_from_mask(
+    mask_file: Path | str,
+    alpha_file: Path | str,
+) -> None:
+    """Create an alpha band (255=valid, 0=invalid) from a binary mask.
+
+    Assumes mask convention where 0 = invalid, nonzero = valid.
+    """
+    mask = io.load_gdal(mask_file).astype(bool)
+    alpha = np.where(mask, np.uint8(255), np.uint8(0))
+    io.write_arr(arr=alpha, output_name=alpha_file, like_filename=mask_file)
+
+
+def _geocode_one(
+    in_out: tuple[Path, Path],
+    *,
+    lat_file: Path,
+    lon_file: Path,
+    mask_file: Path | None,
+    output_srs: str | int | None,
+    spacing: tuple[float, float] | None,
+    strides: tuple[int, int] | None,
+    resampling_method: str,
+    creation_options: Sequence[str],
+) -> Path:
+    """Geocode a single file (module-level for pickling)."""
+    in_path, out_path = in_out
+    geocode_with_geolocation_arrays(
+        input_file=in_path,
+        lat_file=lat_file,
+        lon_file=lon_file,
+        output_file=out_path,
+        mask_file=mask_file,
+        output_srs=output_srs,
+        spacing=spacing,
+        strides=strides,
+        resampling_method=resampling_method,
+        creation_options=creation_options,
+    )
+    return out_path
+
+
+def run(
+    input_files: Annotated[
+        list[Path],
+        tyro.conf.arg(
+            aliases=["-i", "--input"],
+            help="Input file(s) to geocode. Can be specified multiple times.",
+        ),
+    ],
+    output: Annotated[
+        Path | None,
+        tyro.conf.arg(
+            aliases=["-o"],
+            help=(
+                "Output path. For single input, this is the output file path. "
+                "For multiple inputs, this should be a directory (files will be "
+                "named <input>.geo.tif). If not provided, outputs are written "
+                "alongside inputs."
+            ),
+        ),
+    ] = None,
+    geometry_dir: Annotated[
+        Path | None,
+        tyro.conf.arg(
+            aliases=["-g", "--geometry"],
+            help=(
+                "Geometry directory containing y.tif (lat) and x.tif (lon). "
+                "Shorthand for --lat <dir>/y.tif --lon <dir>/x.tif."
+            ),
+        ),
+    ] = None,
+    lat_file: Annotated[
+        Path | None,
+        tyro.conf.arg(
+            aliases=["--lat"],
+            help="Path to latitude geolocation file.",
+        ),
+    ] = None,
+    lon_file: Annotated[
+        Path | None,
+        tyro.conf.arg(
+            aliases=["--lon"],
+            help="Path to longitude geolocation file.",
+        ),
+    ] = None,
+    mask: Annotated[
+        Path | None,
+        tyro.conf.arg(
+            help=(
+                "Mask file to apply during geocoding (0=invalid, nonzero=valid)."
+                " Should match input resolution, or full resolution if strides"
+                " are read from --config."
+            ),
+        ),
+    ] = None,
+    output_srs: Annotated[
+        str | int | None,
+        tyro.conf.arg(
+            aliases=["--srs"],
+            help=(
+                "Output spatial reference system as EPSG code (e.g., 32610 for UTM"
+                " 10N) or proj4/WKT string. Defaults to EPSG:4326 (WGS84 lat/lon)."
+            ),
+        ),
+    ] = None,
+    spacing: Annotated[
+        float | None,
+        tyro.conf.arg(
+            aliases=["-s"],
+            help=(
+                "Output pixel spacing in output SRS units (degrees for EPSG:4326, "
+                "meters for UTM). If not provided, GDAL determines automatically."
+            ),
+        ),
+    ] = None,
+    config: Annotated[
+        Path | None,
+        tyro.conf.arg(
+            aliases=["-c"],
+            help=(
+                "Path to dolphin_config.yaml. Reads"
+                " output_options.strides to determine the decimation factor"
+                " of input files relative to the lat/lon geolocation files."
+            ),
+        ),
+    ] = None,
+    resampling_method: str = "near",
+    creation_options: Sequence[str] = DEFAULT_TIFF_OPTIONS,
+    max_workers: Annotated[
+        int | None,
+        tyro.conf.arg(
+            aliases=["-j", "--jobs"],
+            help="Max parallel workers. Defaults to number of CPUs.",
+        ),
+    ] = None,
+) -> list[Path]:
+    r"""Geocode rasters using latitude/longitude geolocation arrays.
+
+    Transforms rasters from radar/swath geometry to geographic coordinates
+    using per-pixel lat/lon arrays (e.g., from ISCE2/ISCE3 topo).
+
+    Examples
+    --------
+    Single file with geometry directory:
+
+        dolphin geocode -i interferogram.tif -g geometry/
+
+    Multiple files to output directory:
+
+        dolphin geocode -i ifg.tif -i coherence.tif -g geometry/ -o geocoded/
+
+    With mask and strides from dolphin config (for multilooked outputs):
+
+        dolphin geocode -i ifg.tif -g geometry/ --mask mask.tif -c dolphin_config.yaml
+
+    Output to UTM with 30m spacing:
+
+        dolphin geocode -i ifg.tif -g geometry/ --srs 32610 -s 30
+
+    Using explicit lat/lon files:
+
+        dolphin geocode -i ifg.tif --lat y.tif --lon x.tif
+
+    """
+    # Resolve lat/lon files
+    if geometry_dir is not None:
+        geometry_dir = Path(geometry_dir)
+        lat_file = geometry_dir / "y.tif"
+        lon_file = geometry_dir / "x.tif"
+
+    if lat_file is None or lon_file is None:
+        msg = "Must provide either --geometry or both --lat and --lon"
+        raise ValueError(msg)
+
+    lat_file = Path(lat_file)
+    lon_file = Path(lon_file)
+    assert lat_file.exists(), f"Lat file not found: {lat_file}"
+    assert lon_file.exists(), f"Lon file not found: {lon_file}"
+
+    # Read strides from dolphin config
+    parsed_strides: tuple[int, int] | None = None
+    if config is not None:
+        from dolphin.workflows.config import DisplacementWorkflow
+
+        cfg = DisplacementWorkflow.from_yaml(config)
+        sy = cfg.output_options.strides.y
+        sx = cfg.output_options.strides.x
+        if sy != 1 or sx != 1:
+            parsed_strides = (sy, sx)
+            logger.info("Using strides from config: (%d, %d)", sy, sx)
+
+    # Parse spacing
+    parsed_spacing: tuple[float, float] | None = None
+    if spacing is not None:
+        parsed_spacing = (spacing, spacing)
+
+    # Determine output paths
+    multiple_inputs = len(input_files) > 1
+    output_is_dir = output is not None and (output.is_dir() or multiple_inputs)
+
+    if multiple_inputs and output is not None:
+        output.mkdir(parents=True, exist_ok=True)
+
+    # Build list of (input, output) pairs
+    io_pairs: list[tuple[Path, Path]] = []
+    skipped: list[Path] = []
+    for in_file in input_files:
+        in_path = Path(in_file)
+        if output is None:
+            out_path = in_path.with_suffix(f".geo{in_path.suffix}")
+        elif output_is_dir:
+            out_path = output / f"{in_path.stem}.geo{in_path.suffix}"
+        else:
+            out_path = output
+
+        # Skip if output exists and is newer than input
+        if out_path.exists() and out_path.stat().st_mtime >= in_path.stat().st_mtime:
+            logger.debug("Skipping %s (already exists)", out_path.name)
+            skipped.append(out_path)
+        else:
+            io_pairs.append((in_path, out_path))
+
+    if not io_pairs:
+        logger.info("All files already geocoded, skipping")
+        return skipped
+
+    # Geocode in parallel
+    n_workers = max_workers or os.cpu_count() or 1
+    n_workers = min(n_workers, len(io_pairs))
+    logger.info("Geocoding %d file(s) with %d workers", len(io_pairs), n_workers)
+
+    worker = partial(
+        _geocode_one,
+        lat_file=lat_file,
+        lon_file=lon_file,
+        mask_file=mask,
+        output_srs=output_srs,
+        spacing=parsed_spacing,
+        strides=parsed_strides,
+        resampling_method=resampling_method,
+        creation_options=creation_options,
+    )
+
+    output_files: list[Path] = []
+    with ProcessPoolExecutor(max_workers=n_workers) as executor:
+        futures = {executor.submit(worker, pair): pair[1] for pair in io_pairs}
+        for future in as_completed(futures):
+            out_path = future.result()
+            logger.info("Completed: %s", out_path.name)
+            output_files.append(out_path)
+
+    logger.info("Geocoded %d file(s)", len(output_files))
+    return skipped + output_files

--- a/tests/test_geocode.py
+++ b/tests/test_geocode.py
@@ -1,0 +1,333 @@
+"""Tests for the geocode module using synthetic geolocation arrays."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from osgeo import gdal
+
+from dolphin import io
+from dolphin.geocode import (
+    _find_lat_lon_files,
+    find_rasters_to_geocode,
+    geocode_with_geolocation_arrays,
+    run,
+)
+
+gdal.UseExceptions()
+
+# Synthetic scene centered near Mexico City
+LAT_CENTER, LON_CENTER = 19.4, -99.1
+NROWS, NCOLS = 60, 80
+
+
+def _write_float32_raster(path: Path, data: np.ndarray) -> Path:
+    """Write a 2D float32 array to a GeoTIFF (no geotransform/projection)."""
+    driver = gdal.GetDriverByName("GTiff")
+    ds = driver.Create(str(path), data.shape[1], data.shape[0], 1, gdal.GDT_Float32)
+    ds.GetRasterBand(1).WriteArray(data)
+    ds = None
+    return path
+
+
+@pytest.fixture()
+def geometry_dir(tmp_path):
+    """Create synthetic lat/lon geolocation rasters as a linear grid."""
+    geo_dir = tmp_path / "geometry"
+    geo_dir.mkdir()
+
+    lat = np.linspace(LAT_CENTER + 0.3, LAT_CENTER - 0.3, NROWS).reshape(-1, 1)
+    lat = np.broadcast_to(lat, (NROWS, NCOLS)).copy()
+    lon = np.linspace(LON_CENTER - 0.4, LON_CENTER + 0.4, NCOLS).reshape(1, -1)
+    lon = np.broadcast_to(lon, (NROWS, NCOLS)).copy()
+
+    _write_float32_raster(geo_dir / "y.tif", lat.astype(np.float32))
+    _write_float32_raster(geo_dir / "x.tif", lon.astype(np.float32))
+    return geo_dir
+
+
+@pytest.fixture()
+def input_raster(tmp_path):
+    """Create a synthetic input raster (a simple gradient)."""
+    data = np.arange(NROWS * NCOLS, dtype=np.float32).reshape(NROWS, NCOLS)
+    return _write_float32_raster(tmp_path / "input.tif", data)
+
+
+@pytest.fixture()
+def mask_raster(tmp_path, input_raster):
+    """Create a mask that invalidates the left half of the image."""
+    mask = np.ones((NROWS, NCOLS), dtype=np.uint8)
+    mask[:, : NCOLS // 2] = 0
+    path = tmp_path / "mask.tif"
+    io.write_arr(arr=mask, output_name=path, like_filename=input_raster)
+    return path
+
+
+class TestGeocodeWithGeolocationArrays:
+    def test_basic(self, tmp_path, geometry_dir, input_raster):
+        out = tmp_path / "output.geo.tif"
+        result = geocode_with_geolocation_arrays(
+            input_file=input_raster,
+            lat_file=geometry_dir / "y.tif",
+            lon_file=geometry_dir / "x.tif",
+            output_file=out,
+        )
+        assert result == out
+        assert out.exists()
+
+        ds = gdal.Open(str(out))
+        gt = ds.GetGeoTransform()
+        # Output should be placed in the right lon/lat neighborhood
+        assert LON_CENTER - 1 < gt[0] < LON_CENTER + 1
+        assert LAT_CENTER - 1 < gt[3] < LAT_CENTER + 1
+        # Should have non-NaN data
+        arr = ds.GetRasterBand(1).ReadAsArray()
+        assert np.any(np.isfinite(arr))
+
+    def test_default_output_name(self, geometry_dir, input_raster):
+        result = geocode_with_geolocation_arrays(
+            input_file=input_raster,
+            lat_file=geometry_dir / "y.tif",
+            lon_file=geometry_dir / "x.tif",
+        )
+        assert result.name == "input.geo.tif"
+        assert result.exists()
+
+    def test_with_mask(self, tmp_path, geometry_dir, input_raster, mask_raster):
+        out = tmp_path / "masked.geo.tif"
+        result = geocode_with_geolocation_arrays(
+            input_file=input_raster,
+            lat_file=geometry_dir / "y.tif",
+            lon_file=geometry_dir / "x.tif",
+            output_file=out,
+            mask_file=mask_raster,
+        )
+        assert result.exists()
+        ds = gdal.Open(str(out))
+        arr = ds.GetRasterBand(1).ReadAsArray()
+        ds = None
+        # Should have both valid and NaN pixels
+        assert np.any(np.isfinite(arr))
+        assert np.any(np.isnan(arr))
+
+    def test_with_strides(self, tmp_path, geometry_dir):
+        """Strided input: input is smaller than geolocation arrays."""
+        stride_y, stride_x = 2, 2
+        small_rows = NROWS // stride_y
+        small_cols = NCOLS // stride_x
+        small_data = np.arange(small_rows * small_cols, dtype=np.float32).reshape(
+            small_rows, small_cols
+        )
+        small_input = _write_float32_raster(tmp_path / "strided_input.tif", small_data)
+
+        out = tmp_path / "strided.geo.tif"
+        result = geocode_with_geolocation_arrays(
+            input_file=small_input,
+            lat_file=geometry_dir / "y.tif",
+            lon_file=geometry_dir / "x.tif",
+            output_file=out,
+            strides=(stride_y, stride_x),
+        )
+        assert result.exists()
+        ds = gdal.Open(str(out))
+        gt = ds.GetGeoTransform()
+        assert LON_CENTER - 1 < gt[0] < LON_CENTER + 1
+        arr = ds.GetRasterBand(1).ReadAsArray()
+        assert np.any(np.isfinite(arr))
+
+    def test_with_spacing(self, tmp_path, geometry_dir, input_raster):
+        out = tmp_path / "spaced.geo.tif"
+        geocode_with_geolocation_arrays(
+            input_file=input_raster,
+            lat_file=geometry_dir / "y.tif",
+            lon_file=geometry_dir / "x.tif",
+            output_file=out,
+            spacing=0.01,
+        )
+        ds = gdal.Open(str(out))
+        gt = ds.GetGeoTransform()
+        assert abs(gt[1] - 0.01) < 1e-6
+        assert abs(gt[5] + 0.01) < 1e-6
+
+
+def _make_lat_lon_arrays() -> tuple[np.ndarray, np.ndarray]:
+    """Return synthetic lat/lon arrays for the test scene."""
+    lat = np.linspace(LAT_CENTER + 0.3, LAT_CENTER - 0.3, NROWS).reshape(-1, 1)
+    lat = np.broadcast_to(lat, (NROWS, NCOLS)).copy().astype(np.float32)
+    lon = np.linspace(LON_CENTER - 0.4, LON_CENTER + 0.4, NCOLS).reshape(1, -1)
+    lon = np.broadcast_to(lon, (NROWS, NCOLS)).copy().astype(np.float32)
+    return lat, lon
+
+
+class TestFindLatLonFiles:
+    def test_isce3_style(self, tmp_path):
+        """Finds y.tif/x.tif (ISCE3 / dolphin convention)."""
+        lat, lon = _make_lat_lon_arrays()
+        _write_float32_raster(tmp_path / "y.tif", lat)
+        _write_float32_raster(tmp_path / "x.tif", lon)
+        lat_f, lon_f = _find_lat_lon_files(tmp_path)
+        assert lat_f.name == "y.tif"
+        assert lon_f.name == "x.tif"
+
+    def test_isce2_style(self, tmp_path):
+        """Finds lat.rdr/lon.rdr (ISCE2 topsStack / stripmapStack)."""
+        lat, lon = _make_lat_lon_arrays()
+        _write_float32_raster(tmp_path / "lat.rdr", lat)
+        _write_float32_raster(tmp_path / "lon.rdr", lon)
+        lat_f, lon_f = _find_lat_lon_files(tmp_path)
+        assert lat_f.name == "lat.rdr"
+        assert lon_f.name == "lon.rdr"
+
+    def test_isce3_preferred_over_isce2(self, tmp_path):
+        """When both exist, ISCE3 convention wins."""
+        lat, lon = _make_lat_lon_arrays()
+        _write_float32_raster(tmp_path / "y.tif", lat)
+        _write_float32_raster(tmp_path / "x.tif", lon)
+        _write_float32_raster(tmp_path / "lat.rdr", lat)
+        _write_float32_raster(tmp_path / "lon.rdr", lon)
+        lat_f, _lon_f = _find_lat_lon_files(tmp_path)
+        assert lat_f.name == "y.tif"
+
+    def test_error_no_files(self, tmp_path):
+        with pytest.raises(FileNotFoundError, match="No lat/lon files found"):
+            _find_lat_lon_files(tmp_path)
+
+    def test_run_with_isce2_geometry(self, tmp_path):
+        """End-to-end: run() auto-detects ISCE2 lat.rdr/lon.rdr."""
+        geo_dir = tmp_path / "geom_reference"
+        geo_dir.mkdir()
+        lat, lon = _make_lat_lon_arrays()
+        _write_float32_raster(geo_dir / "lat.rdr", lat)
+        _write_float32_raster(geo_dir / "lon.rdr", lon)
+
+        data = np.arange(NROWS * NCOLS, dtype=np.float32).reshape(NROWS, NCOLS)
+        input_file = _write_float32_raster(tmp_path / "input.tif", data)
+
+        out = tmp_path / "output.geo.tif"
+        result = run(
+            input_files=[input_file],
+            geometry_dir=geo_dir,
+            output=out,
+        )
+        assert len(result) == 1
+        assert result[0].exists()
+        ds = gdal.Open(str(out))
+        gt = ds.GetGeoTransform()
+        assert LON_CENTER - 1 < gt[0] < LON_CENTER + 1
+
+
+class TestFindRastersToGeocode:
+    @pytest.fixture()
+    def dolphin_dir(self, tmp_path):
+        """Create a mock dolphin directory structure with empty rasters."""
+        d = tmp_path / "dolphin_work"
+        ts_dir = d / "timeseries"
+        ts_dir.mkdir(parents=True)
+        unw_dir = d / "unwrapped"
+        unw_dir.mkdir()
+        ifg_dir = d / "interferograms"
+        ifg_dir.mkdir()
+
+        dummy = np.zeros((4, 4), dtype=np.float32)
+        for name in [
+            "timeseries/20220101_20220102.tif",
+            "timeseries/20220102_20220103.tif",
+            "timeseries/velocity.tif",
+            "unwrapped/20220101_20220102.unw.tif",
+            "interferograms/20220101_20220102.int.tif",
+            "interferograms/similarity_20220101.tif",
+            "interferograms/temporal_coherence.tif",
+            "interferograms/multilooked_coherence.tif",
+            "interferograms/crlb_velocity.tif",
+            "interferograms/amp_dispersion_looked.tif",
+        ]:
+            _write_float32_raster(d / name, dummy)
+
+        return d
+
+    def test_defaults(self, dolphin_dir):
+        """By default, finds timeseries + unwrapped."""
+        rasters = find_rasters_to_geocode(dolphin_dir)
+        names = {r.name for r in rasters}
+        assert "velocity.tif" in names
+        assert "20220101_20220102.tif" in names
+        assert "20220101_20220102.unw.tif" in names
+        # Should NOT include interferograms or auxiliary by default
+        assert "20220101_20220102.int.tif" not in names
+        assert "crlb_velocity.tif" not in names
+
+    def test_include_interferograms(self, dolphin_dir):
+        rasters = find_rasters_to_geocode(dolphin_dir, include_interferograms=True)
+        names = {r.name for r in rasters}
+        assert "20220101_20220102.int.tif" in names
+        assert "similarity_20220101.tif" in names
+        assert "temporal_coherence.tif" in names
+        assert "multilooked_coherence.tif" in names
+
+    def test_include_auxiliary(self, dolphin_dir):
+        rasters = find_rasters_to_geocode(dolphin_dir, include_auxiliary=True)
+        names = {r.name for r in rasters}
+        assert "crlb_velocity.tif" in names
+        assert "amp_dispersion_looked.tif" in names
+
+    def test_exclude_unwrapped(self, dolphin_dir):
+        rasters = find_rasters_to_geocode(dolphin_dir, include_unwrapped=False)
+        names = {r.name for r in rasters}
+        assert "20220101_20220102.unw.tif" not in names
+
+
+class TestRun:
+    def test_single_file(self, tmp_path, geometry_dir, input_raster):
+        out = tmp_path / "out.geo.tif"
+        result = run(
+            input_files=[input_raster],
+            geometry_dir=geometry_dir,
+            output=out,
+        )
+        assert len(result) == 1
+        assert result[0].exists()
+
+    def test_dolphin_dir(self, tmp_path, geometry_dir):
+        """Test bulk geocode from a dolphin work directory."""
+        # Build a minimal dolphin directory
+        dolphin_dir = tmp_path / "dolphin_work"
+        ts_dir = dolphin_dir / "timeseries"
+        ts_dir.mkdir(parents=True)
+
+        data = np.arange(NROWS * NCOLS, dtype=np.float32).reshape(NROWS, NCOLS)
+        _write_float32_raster(ts_dir / "20220101_20220102.tif", data)
+        _write_float32_raster(ts_dir / "velocity.tif", data * 0.1)
+
+        result = run(
+            dolphin_dir=dolphin_dir,
+            geometry_dir=geometry_dir,
+            include_unwrapped=False,
+        )
+        assert len(result) == 2
+        geocoded_dir = dolphin_dir / "geocoded"
+        assert geocoded_dir.exists()
+        # Directory structure should be mirrored
+        assert (geocoded_dir / "timeseries" / "20220101_20220102.tif").exists()
+        assert (geocoded_dir / "timeseries" / "velocity.tif").exists()
+
+    def test_skips_existing(self, tmp_path, geometry_dir, input_raster):
+        """Running twice should skip on the second call."""
+        out = tmp_path / "out.geo.tif"
+        run(
+            input_files=[input_raster],
+            geometry_dir=geometry_dir,
+            output=out,
+        )
+        # Second run should skip
+        result = run(
+            input_files=[input_raster],
+            geometry_dir=geometry_dir,
+            output=out,
+        )
+        assert len(result) == 1
+
+    def test_error_no_inputs(self, geometry_dir):
+        with pytest.raises(ValueError, match="Must provide"):
+            run(geometry_dir=geometry_dir)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary


Created `src/dolphin/geocode.py` with:

  - `geocode_with_geolocation_arrays()` - Core function that geocodes a single raster using lat/lon geolocation arrays via GDAL's geolocation warping. Handles strides (multilooked inputs vs full-res lat/lon) by
  subsampling lat/lon via VRT. Optional mask support with alpha band.
  - `run()` - CLI entry point for batch geocoding multiple files in parallel. Supports:
    - -i for input files (multiple allowed)
    - -g for geometry directory (expects y.tif/x.tif) or --lat/--lon individually
    - --strides ROW,COL for multilooked dolphin outputs
    - --mask for masking (0=invalid, nonzero=valid convention)
    - --srs for output CRS, -s for spacing
    - -j for parallel workers
  - Helper functions: _create_subsampled_vrt() for stride handling, _create_alpha_from_mask() for mask-to-alpha conversion
<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review
