### PR TITLE
Add weighted closure-phase coefficient (gamma_CPw) reliability raster

### DIFF
--- a/src/dolphin/phase_link/_closure_phase.py
+++ b/src/dolphin/phase_link/_closure_phase.py
@@ -38,3 +38,76 @@ def compute_nearest_closure_phases_batch(
 
     """
     return jax.vmap(jax.vmap(compute_nearest_closure_phases))(cov_matrices)
+
+
+@jax.jit
+def closure_phase_coefficient(C: Array) -> Array:
+    r"""Weighted closure-phase coefficient :math:`\gamma_{CPw}`.
+
+    A method-independent reliability indicator computed directly from the sample
+    coherence matrix, defined in [@Heimpel2026Heuristic] as
+
+    .. math::
+
+        \gamma_{CPw} = \max\!\Bigl(
+            \frac{\sum_{i<j<k} |T_{ij} T_{jk} T_{ki}| \cos\phi^{\Delta}_{ijk}}
+                 {\sum_{i<j<k} |T_{ij} T_{jk} T_{ki}|},
+            \; 0 \Bigr)
+
+    where :math:`\phi^{\Delta}_{ijk} = \angle(T_{ij} T_{jk} T_{ki})` is the triplet
+    closure phase. Equals 1 for a rank-1 outer product :math:`T = vv^H` (exact
+    linkage) and 0 when :math:`T = I_N` (no coherence).
+
+    The triplet sum is evaluated in closed form to avoid materializing the
+    :math:`O(n^3)` tensor of triplet products per pixel. Because both the numerator
+    integrand :math:`\mathrm{Re}(T_{ij} T_{jk} T_{ki})` and the denominator
+    integrand :math:`|T_{ij} T_{jk} T_{ki}|` are invariant under permutations of
+    :math:`(i,j,k)` (for Hermitian :math:`T` with real unit diagonal), summing
+    over ordered triplets equals :math:`1/6` of the sum over all index tuples,
+    and the degenerate (two or three equal indices) terms cancel cleanly:
+
+    .. math::
+
+        \sum_{i<j<k} \mathrm{Re}(T_{ij} T_{jk} T_{ki})
+          = [\mathrm{Re}(\mathrm{tr}(T^3)) - 3 \|T\|_F^2 + 2n] / 6
+
+        \sum_{i<j<k} |T_{ij} T_{jk} T_{ki}|
+          = [\mathrm{tr}(|T|^3) - 3 \|T\|_F^2 + 2n] / 6
+
+    The factor of :math:`1/6` cancels in the ratio, leaving two :math:`n \times n`
+    matrix multiplications per pixel.
+
+    Parameters
+    ----------
+    C : Array
+        Complex Hermitian sample coherence matrix, shape (..., n, n), with
+        unit-magnitude diagonal.
+
+    Returns
+    -------
+    Array
+        :math:`\gamma_{CPw}` values with shape equal to the leading dims of `C`,
+        in [0, 1].
+
+    References
+    ----------
+    .. [1] Heimpel et al., "Heuristic quality coefficients for interferometric
+       phase linking", ISPRS J. Photogramm. Remote Sens. 237 (2026) 1-21.
+       doi:10.1016/j.isprsjprs.2026.04.015
+
+    """
+    A = jnp.abs(C)
+    n = C.shape[-1]
+    T2 = C @ C
+    A2 = A @ A
+    # ||T||_F^2 = sum |T_ij|^2
+    fro_sq = jnp.sum(A * A, axis=(-2, -1))
+    # tr(T^3) = <T^2, T>_F = sum T2_ij * conj(T_ij); real for Hermitian T.
+    tr_T3 = jnp.real(jnp.sum(T2 * jnp.conj(C), axis=(-2, -1)))
+    # tr(|T|^3) = <A^2, A>_F for real symmetric A = |T|.
+    tr_A3 = jnp.sum(A2 * A, axis=(-2, -1))
+    num = tr_T3 - 3.0 * fro_sq + 2.0 * n
+    den = tr_A3 - 3.0 * fro_sq + 2.0 * n
+    # For n < 3 (no triplets) or an all-zero window, den == 0; return 0.
+    safe_den = jnp.where(den > 0, den, 1.0)
+    return jnp.maximum(jnp.where(den > 0, num / safe_den, 0.0), 0.0)

--- a/src/dolphin/phase_link/_core.py
+++ b/src/dolphin/phase_link/_core.py
@@ -16,7 +16,10 @@ from dolphin._types import HalfWindow, Strides
 from dolphin.utils import take_looks
 
 from . import covariance, crlb, metrics
-from ._closure_phase import compute_nearest_closure_phases_batch
+from ._closure_phase import (
+    closure_phase_coefficient,
+    compute_nearest_closure_phases_batch,
+)
 from ._eigenvalues import eigh_largest_stack, eigh_smallest_stack
 from ._ps_filling import fill_ps_pixels
 
@@ -62,6 +65,14 @@ class PhaseLinkOutput(NamedTuple):
 
     closure_phases: np.ndarray
     """The closure phases at each pixel, for N-2 images."""
+
+    closure_phase_coh: np.ndarray
+    """Weighted closure-phase coefficient (gamma_CPw) at each pixel.
+
+    A method-independent reliability indicator in [0, 1] computed directly from
+    the sample coherence matrix (Heimpel et al. 2026, Eq. 3.16-3.17). Equals 1
+    for an exact rank-1 linkage and 0 for fully decorrelated noise.
+    """
 
 
 def run_phase_linking(
@@ -233,9 +244,11 @@ def run_phase_linking(
         slcs_decimated = decimate(slc_stack, strides)
         cpx_phase = np.exp(1j * np.angle(cpx_phase)) * np.abs(slcs_decimated)
 
+    closure_phase_coh = np.array(cpl_out.closure_phase_coh)
     # Finally, ensure the nodata regions are 0
     cpx_phase[:, mask_looked] = np.nan
     temp_coh[mask_looked] = np.nan
+    closure_phase_coh[mask_looked] = np.nan
 
     return PhaseLinkOutput(
         cpx_phase=cpx_phase,
@@ -246,6 +259,7 @@ def run_phase_linking(
         estimator=np.asarray(cpl_out.estimator),
         crlb_std_dev=np.array(cpl_out.crlb_std_dev),
         closure_phases=np.asarray(cpl_out.closure_phases),
+        closure_phase_coh=closure_phase_coh,
     )
 
 
@@ -337,6 +351,7 @@ def run_cpl(
         C_arrays = C_arrays.at[:, :, l_rows, l_cols].set(0.0 + 0j)
 
     closure_phases = compute_nearest_closure_phases_batch(C_arrays)
+    closure_phase_coh = closure_phase_coefficient(C_arrays)
     # For a more conservative uncertainty estimate, use a smaller number of looks
     # rather than `num_looks = (2 * half_window[0] + 1) * (2 * half_window[1] + 1)`
     num_looks = math.sqrt(half_window[0] * half_window[1])
@@ -373,6 +388,7 @@ def run_cpl(
         estimator=estimator,
         crlb_std_dev=crlb_std_dev_reshaped,
         closure_phases=closure_phases,
+        closure_phase_coh=closure_phase_coh,
     )
 
 

--- a/src/dolphin/workflows/displacement.py
+++ b/src/dolphin/workflows/displacement.py
@@ -36,6 +36,7 @@ class OutputPaths:
     stitched_similarity_files: list[Path]
     stitched_crlb_files: list[Path]
     stitched_closure_phase_files: list[Path]
+    stitched_closure_phase_coh_files: list[Path]
     stitched_ps_file: Path
     stitched_amp_dispersion_file: Path
     unwrapped_paths: list[Path] | None
@@ -139,6 +140,7 @@ def run(
     crlb_files: list[Path] = []
     closure_phase_files: list[Path] = []
     temp_coh_file_list: list[Path] = []
+    closure_phase_coh_file_list: list[Path] = []
     ps_file_list: list[Path] = []
     amp_dispersion_file_list: list[Path] = []
     shp_count_file_list: list[Path] = []
@@ -183,6 +185,7 @@ def run(
                 cur_closure_phase_files,
                 comp_slcs,
                 temp_coh_files,
+                closure_phase_coh_files,
                 ps_file,
                 amp_disp_file,
                 shp_count_files,
@@ -193,6 +196,7 @@ def run(
             closure_phase_files.extend(cur_closure_phase_files)
             comp_slc_dict[burst] = comp_slcs
             temp_coh_file_list.extend(temp_coh_files)
+            closure_phase_coh_file_list.extend(closure_phase_coh_files)
             ps_file_list.append(ps_file)
             amp_dispersion_file_list.append(amp_disp_file)
             shp_count_file_list.extend(shp_count_files)
@@ -209,6 +213,7 @@ def run(
     stitched_paths = stitching_bursts.run(
         ifg_file_list=ifg_file_list,
         temp_coh_file_list=temp_coh_file_list,
+        closure_phase_coh_file_list=closure_phase_coh_file_list,
         ps_file_list=ps_file_list,
         crlb_file_list=crlb_files,
         amp_dispersion_list=amp_dispersion_file_list,
@@ -238,6 +243,7 @@ def run(
             stitched_similarity_files=stitched_paths.similarity_files,
             stitched_crlb_files=stitched_paths.crlb_paths,
             stitched_closure_phase_files=stitched_paths.closure_phase_files,
+            stitched_closure_phase_coh_files=stitched_paths.closure_phase_coh_files,
             unwrapped_paths=None,
             conncomp_paths=None,
             timeseries_paths=None,
@@ -310,6 +316,7 @@ def run(
         stitched_temp_coh_files=stitched_paths.temp_coh_files,
         stitched_crlb_files=stitched_paths.crlb_paths,
         stitched_closure_phase_files=stitched_paths.closure_phase_files,
+        stitched_closure_phase_coh_files=stitched_paths.closure_phase_coh_files,
         stitched_ps_file=stitched_paths.ps_file,
         stitched_amp_dispersion_file=stitched_paths.amp_dispersion_file,
         stitched_shp_count_files=stitched_paths.shp_count_files,

--- a/src/dolphin/workflows/sequential.py
+++ b/src/dolphin/workflows/sequential.py
@@ -58,7 +58,14 @@ def run_wrapped_phase_sequential(
     max_workers: int = 1,
     **tqdm_kwargs,
 ) -> tuple[
-    list[Path], list[Path], list[Path], list[Path], list[Path], list[Path], list[Path]
+    list[Path],
+    list[Path],
+    list[Path],
+    list[Path],
+    list[Path],
+    list[Path],
+    list[Path],
+    list[Path],
 ]:
     """Estimate wrapped phase using batches of ministacks."""
     if strides is None:
@@ -95,6 +102,7 @@ def run_wrapped_phase_sequential(
     crlb_files: list[Path] = []
     closure_phase_files: list[Path] = []
     temp_coh_files: list[Path] = []
+    closure_phase_coh_files: list[Path] = []
     similarity_files: list[Path] = []
     shp_count_files: list[Path] = []
 
@@ -152,6 +160,7 @@ def run_wrapped_phase_sequential(
             cur_closure_phase_files,
             _cur_comp_slc_file,
             temp_coh_file,
+            closure_phase_coh_file,
             similarity_file,
             shp_count_file,
         ) = _get_outputs_from_folder(cur_output_folder)
@@ -159,6 +168,7 @@ def run_wrapped_phase_sequential(
         closure_phase_files.extend(cur_closure_phase_files)
         output_slc_files.extend(cur_output_files)
         temp_coh_files.append(temp_coh_file)
+        closure_phase_coh_files.append(closure_phase_coh_file)
         similarity_files.append(similarity_file)
         shp_count_files.append(shp_count_file)
 
@@ -171,12 +181,16 @@ def run_wrapped_phase_sequential(
         return tmp
 
     temp_coh_files = move_to_output(temp_coh_files, output_folder)
+    closure_phase_coh_files = move_to_output(closure_phase_coh_files, output_folder)
     shp_count_files = move_to_output(shp_count_files, output_folder)
     similarity_files = move_to_output(similarity_files, output_folder)
 
     # Average the temporal coherence files in each ministack
     full_span = ministack_planner.real_slc_date_range_str
     avg_temp_coh_file = output_folder / f"temporal_coherence_average_{full_span}.tif"
+    avg_closure_phase_coh_file = (
+        output_folder / f"closure_phase_coh_average_{full_span}.tif"
+    )
     avg_shp_count_file = output_folder / f"shp_counts_average_{full_span}.tif"
 
     # we can pass the list of files to gdal_calc, which interprets it
@@ -184,8 +198,12 @@ def run_wrapped_phase_sequential(
 
     if len(temp_coh_files) > 1:
         _average_or_rename(temp_coh_files, avg_temp_coh_file, "Float32")
+        _average_or_rename(
+            closure_phase_coh_files, avg_closure_phase_coh_file, "Float32"
+        )
         _average_or_rename(shp_count_files, avg_shp_count_file, "Int16")
         temp_coh_files.append(avg_temp_coh_file)
+        closure_phase_coh_files.append(avg_closure_phase_coh_file)
         shp_count_files.append(avg_shp_count_file)
 
     if len(similarity_files) > 1:
@@ -222,6 +240,7 @@ def run_wrapped_phase_sequential(
         closure_phase_files,
         comp_slc_outputs,
         temp_coh_files,
+        closure_phase_coh_files,
         shp_count_files,
         similarity_files,
     )
@@ -229,11 +248,12 @@ def run_wrapped_phase_sequential(
 
 def _get_outputs_from_folder(
     output_folder: Path,
-) -> tuple[list[Path], list[Path], list[Path], Path, Path, Path, Path]:
+) -> tuple[list[Path], list[Path], list[Path], Path, Path, Path, Path, Path]:
     cur_output_files = sorted(output_folder.glob("2*.slc.tif"))
 
     cur_comp_slc_file = next(output_folder.glob("compressed_*"))
     temp_coh_file = next(output_folder.glob("temporal_coherence_*"))
+    closure_phase_coh_file = next(output_folder.glob("closure_phase_coh_*"))
     similarity_file = next(output_folder.glob("similarity*"))
     shp_count_file = next(output_folder.glob("shp_counts_*"))
     crlb_files = sorted(output_folder.glob("crlb/crlb*tif"))
@@ -245,6 +265,7 @@ def _get_outputs_from_folder(
         closure_phase_files,
         cur_comp_slc_file,
         temp_coh_file,
+        closure_phase_coh_file,
         similarity_file,
         shp_count_file,
     )

--- a/src/dolphin/workflows/single.py
+++ b/src/dolphin/workflows/single.py
@@ -159,6 +159,9 @@ def run_wrapped_phase_single(
         "temporal_coherence": OutputFile(
             output_folder / f"temporal_coherence_{start_end}.tif", np.float32, strides
         ),
+        "closure_phase_coh": OutputFile(
+            output_folder / f"closure_phase_coh_{start_end}.tif", np.float32, strides
+        ),
         "shp_counts": OutputFile(
             output_folder / f"shp_counts_{start_end}.tif", np.uint16, strides
         ),
@@ -279,6 +282,7 @@ def run_wrapped_phase_single(
         np.nan_to_num(pl_output.cpx_phase, copy=False)
         np.nan_to_num(pl_output.crlb_std_dev, copy=False)
         np.nan_to_num(pl_output.temp_coh, copy=False)
+        np.nan_to_num(pl_output.closure_phase_coh, copy=False)
 
         # Compress the ministack using only the non-compressed SLCs
         # Get the mean to set as pixel magnitudes
@@ -348,6 +352,7 @@ def run_wrapped_phase_single(
             # All other outputs are strided (smaller in size)
             out_datas: dict[str, np.ndarray] = {
                 "temporal_coherence": pl_output.temp_coh,
+                "closure_phase_coh": pl_output.closure_phase_coh,
                 "shp_counts": pl_output.shp_counts,
                 "eigenvalues": pl_output.eigenvalues,
                 "estimator": pl_output.estimator,

--- a/src/dolphin/workflows/stitching_bursts.py
+++ b/src/dolphin/workflows/stitching_bursts.py
@@ -39,6 +39,8 @@ class StitchedOutputs:
     """List of Paths to Cramer Rao Lower Bound (CRLB) files created."""
     closure_phase_files: list[Path]
     """List of Paths to closure phase files created."""
+    closure_phase_coh_files: list[Path]
+    """List of Paths to weighted closure-phase coefficient (gamma_CPw) files."""
     ps_file: Path
     """Path to ps mask file created."""
     amp_dispersion_file: Path
@@ -52,6 +54,7 @@ def run(
     ps_file_list: Sequence[Path],
     crlb_file_list: Sequence[Path],
     closure_phase_file_list: Sequence[Path],
+    closure_phase_coh_file_list: Sequence[Path],
     amp_dispersion_list: Sequence[Path],
     shp_count_file_list: Sequence[Path],
     similarity_file_list: Sequence[Path],
@@ -77,6 +80,8 @@ def run(
         Sequence of paths to the (looked) Cramer Rao Lower Bound (CRLB) files.
     closure_phase_file_list : Sequence[Path]
         Sequence of paths to the (looked) closure phase files.
+    closure_phase_coh_file_list : Sequence[Path]
+        Sequence of paths to the weighted closure-phase coefficient files.
     amp_dispersion_list : Sequence[Path]
         Sequence of paths to the (looked) amplitude dispersion files.
     shp_count_file_list : Sequence[Path]
@@ -217,6 +222,20 @@ def run(
     )
     stitched_closure_phase_files = list(date_to_closure_phase_path.values())
 
+    # Stitch the weighted closure-phase coefficient files
+    date_to_closure_phase_coh_path = stitching.merge_by_date(
+        image_file_list=closure_phase_coh_file_list,
+        file_date_fmt=file_date_fmt,
+        output_dir=stitched_ifg_dir,
+        output_prefix="auto",
+        options=EXTRA_COMPRESSED_TIFF_OPTIONS,
+        out_bounds=out_bounds,
+        out_bounds_epsg=output_options.bounds_epsg,
+        dest_epsg=output_options.epsg,
+        num_workers=num_workers,
+    )
+    stitched_closure_phase_coh_files = list(date_to_closure_phase_coh_path.values())
+
     # Stitch the amp dispersion files
     stitched_amp_disp_file = stitched_ifg_dir / "amp_dispersion_looked.tif"
     if not stitched_amp_disp_file.exists():
@@ -235,6 +254,9 @@ def run(
         create_overviews(stitched_ifg_paths, image_type=ImageType.INTERFEROGRAM)
         create_overviews(interferometric_corr_paths, image_type=ImageType.CORRELATION)
         create_overviews(stitched_temp_coh_files, image_type=ImageType.CORRELATION)
+        create_overviews(
+            stitched_closure_phase_coh_files, image_type=ImageType.CORRELATION
+        )
         create_overviews(stitched_shp_count_files, image_type=ImageType.PS)
         create_overviews(stitched_similarity_files, image_type=ImageType.CORRELATION)
         create_image_overviews(stitched_ps_file, image_type=ImageType.PS)
@@ -248,6 +270,7 @@ def run(
         stitched_similarity_files,
         stitched_crlb_files,
         stitched_closure_phase_files,
+        stitched_closure_phase_coh_files,
         stitched_ps_file,
         stitched_amp_disp_file,
     )

--- a/src/dolphin/workflows/wrapped_phase.py
+++ b/src/dolphin/workflows/wrapped_phase.py
@@ -38,6 +38,9 @@ class WrappedPhaseOutput(NamedTuple):
         In the case of a single phase linking step, this is from one phase linking step.
         In the case of sequential phase linking, this from each ministack, and one
         average of all ministacks.
+    closure_phase_coh_files : list[Path]
+        Paths to weighted closure-phase coefficient (gamma_CPw) files created.
+        One per ministack, plus one average across ministacks for sequential runs.
     ps_looked_file : Path
         The multilooked boolean persistent scatterer file.
     amp_disp_looked_file : Path
@@ -60,6 +63,7 @@ class WrappedPhaseOutput(NamedTuple):
     closure_phase_files: list[Path]
     comp_slc_file_list: list[Path]
     temp_coh_files: list[Path]
+    closure_phase_coh_files: list[Path]
     ps_looked_file: Path
     amp_disp_looked_file: Path
     shp_count_files: list[Path]
@@ -199,10 +203,15 @@ def run(
         logger.info(f"Skipping EVD step, {len(phase_linked_slcs)} files already exist")
         comp_slc_list = sorted(pl_path.glob("compressed*tif"))
         temp_coh_files = sorted(pl_path.glob("temporal_coherence*tif"))
+        closure_phase_coh_files = sorted(pl_path.glob("closure_phase_coh*tif"))
         shp_count_files = sorted(pl_path.glob("shp_count*tif"))
         similarity_files = sorted(pl_path.glob("*similarity*tif"))
         crlb_files = sorted(pl_path.rglob("crlb*tif"))
-        closure_phase_files = sorted(pl_path.rglob("closure_phase*tif"))
+        # Match per-triplet closure_phase_<d1>_<d2>_<d3>.tif but not
+        # closure_phase_coh_<start>_<end>.tif (which is a separate scalar raster)
+        closure_phase_files = sorted(
+            f for f in pl_path.rglob("closure_phase_*tif") if "coh" not in f.stem
+        )
     else:
         logger.info(f"Running sequential EMI step in {pl_path}")
         kwargs = tqdm_kwargs | {"desc": f"Phase linking ({pl_path})"}
@@ -224,6 +233,7 @@ def run(
             closure_phase_files,
             comp_slc_list,
             temp_coh_files,
+            closure_phase_coh_files,
             shp_count_files,
             similarity_files,
         ) = sequential.run_wrapped_phase_sequential(
@@ -278,6 +288,7 @@ def run(
             closure_phase_files,
             comp_slc_list,
             temp_coh_files,
+            closure_phase_coh_files,
             ps_looked_file,
             amp_disp_looked_file,
             shp_count_files,
@@ -325,6 +336,7 @@ def run(
         closure_phase_files,
         comp_slc_list,
         temp_coh_files,
+        closure_phase_coh_files,
         ps_looked_file,
         amp_disp_looked_file,
         shp_count_files,

--- a/tests/test_phase_link_closure_phase.py
+++ b/tests/test_phase_link_closure_phase.py
@@ -1,8 +1,10 @@
 import jax
 import jax.numpy as jnp
+import numpy as np
 import pytest
 
 from dolphin.phase_link._closure_phase import (
+    closure_phase_coefficient,
     compute_nearest_closure_phases,
     compute_nearest_closure_phases_batch,
 )
@@ -60,3 +62,74 @@ def test_batch_vectorization():
         compute_nearest_closure_phases(C[0, 0]),
         atol=1e-6,
     )
+
+
+class TestClosurePhaseCoefficient:
+    """Tests for the weighted closure-phase coefficient gamma_CPw."""
+
+    @pytest.mark.parametrize("n", [3, 5, 10, 20])
+    def test_identity_is_zero(self, n):
+        """gamma_CPw(T=I) = 0 (fully decorrelated)."""
+        C = jnp.eye(n, dtype=jnp.complex64)
+        assert float(closure_phase_coefficient(C)) == pytest.approx(0.0, abs=1e-6)
+
+    @pytest.mark.parametrize("n", [3, 5, 10, 20])
+    def test_rank1_outer_product_is_one(self, n):
+        """gamma_CPw(T = v v^H) = 1 for unit-modulus v (exact linkage)."""
+        rng = np.random.default_rng(n)
+        phases = rng.uniform(-np.pi, np.pi, n).astype(np.float32)
+        v = jnp.exp(1j * jnp.asarray(phases))
+        C = jnp.outer(v, jnp.conj(v))  # unit diag, rank-1
+        assert float(closure_phase_coefficient(C)) == pytest.approx(1.0, abs=1e-5)
+
+    @pytest.mark.parametrize("n", [4, 8])
+    def test_bounded_0_to_1(self, n):
+        """gamma_CPw is clamped to [0, 1] for Hermitian T with unit diagonal."""
+        rng = np.random.default_rng(0)
+        for _ in range(10):
+            # construct a sample coherence by averaging a few random rank-1s
+            phases = rng.uniform(-np.pi, np.pi, (5, n)).astype(np.float32)
+            vs = np.exp(1j * phases)
+            C = np.mean([np.outer(v, v.conj()) for v in vs], axis=0)
+            # normalize to unit diagonal (standard sample-coherence definition)
+            d = np.sqrt(np.abs(np.diag(C)))
+            C = C / np.outer(d, d)
+            gamma = float(closure_phase_coefficient(jnp.asarray(C)))
+            assert 0.0 <= gamma <= 1.0
+
+    def test_batch_shape_and_values(self):
+        """Batched (r, c, n, n) input returns matching (r, c) output."""
+        r, cc, n = 3, 4, 7
+        # mix identity and rank-1 matrices to get both 0 and 1 outputs
+        rng = np.random.default_rng(99)
+        v = jnp.exp(1j * jnp.asarray(rng.uniform(-np.pi, np.pi, n).astype(np.float32)))
+        C_id = jnp.eye(n, dtype=jnp.complex64)
+        C_r1 = jnp.outer(v, jnp.conj(v))
+        batch = jnp.stack(
+            [
+                jnp.stack([C_id if (i + j) % 2 else C_r1 for j in range(cc)])
+                for i in range(r)
+            ]
+        )
+        out = closure_phase_coefficient(batch)
+        assert out.shape == (r, cc)
+        # Check per-cell: matches what each matrix gives on its own.
+        for i in range(r):
+            for j in range(cc):
+                expected = 0.0 if (i + j) % 2 else 1.0
+                assert float(out[i, j]) == pytest.approx(expected, abs=1e-5)
+
+    def test_noisy_rank1_near_one(self):
+        """gamma_CPw stays high when T is a sample estimate of a rank-1 signal."""
+        n, W = 8, 200
+        rng = np.random.default_rng(7)
+        phases = rng.uniform(-np.pi, np.pi, n).astype(np.float32)
+        v = np.exp(1j * phases)
+        # draw W realizations with small independent phase noise per sample
+        noise = 0.1 * rng.standard_normal((W, n)).astype(np.float32)
+        Omega = v[None, :] * np.exp(1j * noise)
+        C = (Omega.conj().T @ Omega) / W
+        d = np.sqrt(np.abs(np.diag(C)))
+        C = C / np.outer(d, d)
+        gamma = float(closure_phase_coefficient(jnp.asarray(C)))
+        assert gamma > 0.95


### PR DESCRIPTION
## Summary

Adds a new per-pixel reliability raster, the **weighted closure-phase coefficient** $\gamma_{CPw}$ from [Heimpel et al. 2026, ISPRS J. Photogramm. Remote Sens. 237](https://doi.org/10.1016/j.isprsjprs.2026.04.015) (Eq. 3.16–3.17). Unlike temporal coherence, $\gamma_{CPw}$ is computed directly from the sample coherence matrix $T$ and is **independent of the phase-linking solution**, so it can be used as an *a priori* reliability filter before running the expensive PL step (useful for small-mini-stack workflows like DISP-S1 with $M=15$ where $\gamma_t$ alone is known to be uninformative).

- $\gamma_{CPw} = 1$ when $T$ is exactly rank-1 (perfect linkage)
- $\gamma_{CPw} = 0$ when $T = I$ (fully decorrelated)

### Implementation

The triplet sum in Eq. 3.16 is computed via a trace-based rewrite to avoid materializing the $O(n^3)$ tensor of triplet products per pixel. Both the numerator integrand $\mathrm{Re}(T_{ij} T_{jk} T_{ki})$ and the denominator integrand $|T_{ij} T_{jk} T_{ki}|$ are invariant under permutations of $(i,j,k)$ for Hermitian $T$ with real unit diagonal, so summing over ordered triplets equals $1/6$ of the sum over all index tuples. After subtracting the two-equal / three-equal degenerate terms:

```math
\sum_{i<j<k} \mathrm{Re}(T_{ij}\, T_{jk}\, T_{ki}) = \frac{\mathrm{Re}\bigl(\mathrm{tr}(T^3)\bigr) - 3\,\lVert T \rVert_F^2 + 2n}{6}
```

```math
\sum_{i<j<k} |T_{ij}\, T_{jk}\, T_{ki}| = \frac{\mathrm{tr}\bigl(|T|^3\bigr) - 3\,\lVert T \rVert_F^2 + 2n}{6}
```

The $1/6$ cancels in the ratio, leaving **two $n \times n$ complex matmuls per pixel** (one for $T^2$, one for $|T|^2$), vectorized across the pixel block via JAX broadcasting.

### Output

A new strided float32 raster `closure_phase_coh_<start_end>.tif` is written per ministack, averaged across ministacks (`closure_phase_coh_average_<full_span>.tif`), and stitched by date in `stitching_bursts.py` — exactly matching the existing `temporal_coherence_*.tif` pattern.

### Files touched

- `phase_link/_closure_phase.py` — new `closure_phase_coefficient()` JAX function
- `phase_link/_core.py` — `PhaseLinkOutput.closure_phase_coh` field, computed in `run_cpl`
- `workflows/single.py` — writes the per-ministack raster
- `workflows/sequential.py` — collects, renames, averages
- `workflows/wrapped_phase.py` + `displacement.py` — threads through output NamedTuples
- `workflows/stitching_bursts.py` — stitches by date, with optional overviews
- `tests/test_phase_link_closure_phase.py` — +5 test groups: $T=I \to 0$, $T=vv^H \to 1$, batch shape, [0,1] bounds, noisy rank-1 near 1

## Test plan

- [x] Unit tests: `T=I` → 0 and `T=vv^H` → 1 at multiple sizes, batch shape, [0,1] bounds, noisy rank-1 ≈ 1 (26 tests pass)
- [x] Workflow smoke tests: `test_workflows_displacement.py` all pass (7/7)
- [x] No regressions in `phase_link`-adjacent tests: 273/274 pass; the one failure (`test_corrections_run_single`) is pre-existing on `main`
- [x] Pre-commit hooks pass (black, ruff, mypy)

## Notes

Branched off `main` for a clean upstream-ready diff; will also merge into `develop-scott` after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)